### PR TITLE
lint: add ruff rules, fix all ruff+mypy errors, add pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.2
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+  - repo: local
+    hooks:
+      - id: mypy
+        name: mypy
+        entry: .venv/bin/mypy python/lattigo/ python/orion-compiler/ python/orion-evaluator/
+        language: system
+        types: [python]
+        pass_filenames: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,15 +44,14 @@ target-version = "py311"
 line-length = 99
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I", "UP", "B", "SIM", "RUF"]
+preview = true
+explicit-preview-rules = true
+select = ["E", "F", "W", "I", "UP", "B", "SIM", "RUF", "PLC0415"]
 ignore = [
     "SIM105",  # contextlib.suppress — __del__ try/except/pass is canonical for Go handle cleanup
     "F403",    # star imports — intentional in nn/__init__.py
     "F405",    # may be undefined from star imports — consequence of F403
 ]
-
-[tool.ruff.lint.per-file-ignores]
-"python/tests/*" = ["SIM115"]  # open().read() is fine in tests
 
 [tool.ruff.format]
 quote-style = "double"

--- a/python/lattigo/lattigo/ckks.py
+++ b/python/lattigo/lattigo/ckks.py
@@ -41,7 +41,9 @@ class Parameters:
         )
 
     # Keys accepted by __init__ (used by from_dict to filter extras).
-    _KNOWN_KEYS = frozenset({"logn", "logq", "logp", "log_default_scale", "ring_type", "h", "log_nth_root"})
+    _KNOWN_KEYS = frozenset(
+        {"logn", "logq", "logp", "log_default_scale", "ring_type", "h", "log_nth_root"}
+    )
 
     @classmethod
     def from_dict(cls, d: dict) -> Parameters:

--- a/python/orion-compiler/orion_compiler/compiled_model.py
+++ b/python/orion-compiler/orion_compiler/compiled_model.py
@@ -8,7 +8,7 @@ import json
 import os
 import struct
 import tempfile
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -24,7 +24,7 @@ class BlobStore:
     """
 
     def __init__(self) -> None:
-        self._file = tempfile.TemporaryFile()
+        self._file = tempfile.TemporaryFile()  # noqa: SIM115
         self._entries: list[tuple[int, int]] = []  # (offset, length)
 
     def append(self, data: bytes) -> int:
@@ -43,7 +43,7 @@ class BlobStore:
         self._file.seek(offset)
         return self._file.read(length)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[bytes]:
         for i in range(len(self._entries)):
             yield self[i]
 
@@ -55,6 +55,7 @@ class BlobStore:
             self.close()
         except Exception:
             pass
+
 
 # -- Binary format helpers --
 
@@ -376,7 +377,7 @@ class CompiledModel:
         }
 
     def to_bytes(self) -> bytes:
-        return _pack_container(_MODEL_MAGIC, self._build_metadata(), self.blobs)
+        return _pack_container(_MODEL_MAGIC, self._build_metadata(), list(self.blobs))
 
     def to_file(self, path: str | os.PathLike[str]) -> None:
         """Write the compiled model to a file, streaming blobs one at a time.

--- a/python/orion-compiler/orion_compiler/compiler.py
+++ b/python/orion-compiler/orion_compiler/compiler.py
@@ -13,7 +13,8 @@ import math
 import os
 import struct
 import time
-from typing import IO, Any
+from collections.abc import Callable
+from typing import Any
 
 import torch
 from torch.utils.data import DataLoader, RandomSampler
@@ -190,9 +191,7 @@ class Compiler:
         This method has ZERO Go/Lattigo dependency — only fit() needs Go.
         """
         blob_store = BlobStore()
-        metadata, blob_count = self._compile_core(
-            lambda data: blob_store.append(data)
-        )
+        metadata, blob_count = self._compile_core(lambda data: blob_store.append(data))
         return CompiledModel(
             params=self.ckks_params,
             config=self.config,
@@ -221,14 +220,14 @@ class Compiler:
             blob_count_pos = f.tell()
             f.write(struct.pack("<I", 0))  # placeholder
 
+            counter = [0]
+
             def write_blob(data: bytes) -> int:
-                idx = write_blob.count
+                idx = counter[0]
                 f.write(struct.pack("<Q", len(data)))
                 f.write(data)
-                write_blob.count += 1
+                counter[0] += 1
                 return idx
-
-            write_blob.count = 0
 
             metadata, blob_count = self._compile_core(write_blob)
 
@@ -247,7 +246,7 @@ class Compiler:
 
     def _compile_core(
         self,
-        emit_blob: ...,
+        emit_blob: Callable[[bytes], int],
     ) -> tuple[dict[str, Any], int]:
         """Shared compilation logic.
 
@@ -308,12 +307,12 @@ class Compiler:
                 module.generate_diagonals(last=(node == last_linear))
 
                 # Pack diagonals and emit immediately
-                module._early_blob_refs: dict[str, int] = {}
-                module._diag_indices_per_block: dict[tuple[int, int], list[int]] = {}
+                module._early_blob_refs = {}  # type: ignore[assignment]
+                module._diag_indices_per_block = {}  # type: ignore[assignment]
                 for (row, col), diag_dict in module.diagonals.items():
                     blob_data = pack_raw_diagonals(diag_dict, max_slots)
-                    module._early_blob_refs[f"diag_{row}_{col}"] = emit_blob(blob_data)
-                    module._diag_indices_per_block[(row, col)] = list(diag_dict.keys())
+                    module._early_blob_refs[f"diag_{row}_{col}"] = emit_blob(blob_data)  # type: ignore[operator,index]
+                    module._diag_indices_per_block[(row, col)] = list(diag_dict.keys())  # type: ignore[operator,assignment]
                     blob_count += 1
 
                 # Replace diagonals with skeleton preserving len() for
@@ -478,7 +477,7 @@ class Compiler:
         self,
         node_name: str,
         module: Module,
-        emit_blob: ...,
+        emit_blob: Callable[[bytes], int],
         max_slots: int,
         slots: int,
         nth_root: int,
@@ -499,8 +498,11 @@ class Compiler:
         if isinstance(module, LinearTransform):
             # Diagonals were already packed during step [3/5].
             # Use pre-saved blob refs and diagonal indices.
-            blob_refs = dict(module._early_blob_refs)
-            diag_indices_per_block = module._diag_indices_per_block
+            blob_refs = dict(module._early_blob_refs)  # type: ignore[arg-type]
+            assert blob_refs is not None
+            diag_indices_per_block: dict[tuple[int, int], list[int]] = (
+                module._diag_indices_per_block  # type: ignore[assignment]
+            )
 
             # Block dimensions from diagonalize: (row, col) keys
             block_keys = list(diag_indices_per_block.keys())

--- a/python/orion-compiler/orion_compiler/core/compiler_backend.py
+++ b/python/orion-compiler/orion_compiler/core/compiler_backend.py
@@ -18,7 +18,6 @@ from lattigo.gohandle import GoHandle
 
 from orion_compiler.params import CKKSParams, CompilerConfig
 
-
 # =========================================================================
 # NewParameters — thin adapter over CKKSParams + CompilerConfig
 # =========================================================================

--- a/python/orion-compiler/orion_compiler/core/packing.py
+++ b/python/orion-compiler/orion_compiler/core/packing.py
@@ -259,7 +259,7 @@ def _extract_diagonals_sparse(
 
     result: dict[int, list[float]] = {}
     groups = np.split(np.arange(len(order)), split_points)
-    for d, group in zip(unique_diags, groups):
+    for d, group in zip(unique_diags, groups, strict=False):
         diag_vec = np.zeros(num_slots, dtype=np.float64)
         diag_vec[sorted_pos[group]] = sorted_vals[group]
         if np.any(diag_vec != 0):
@@ -362,7 +362,10 @@ def diagonalize(
             ]
 
             nonzero_diagonals = _extract_diagonals_sparse(
-                block_sparse, block_height, num_slots, reps,
+                block_sparse,
+                block_height,
+                num_slots,
+                reps,
             )
 
             total_diagonals += len(nonzero_diagonals)

--- a/python/orion-evaluator/orion_evaluator/evaluator.py
+++ b/python/orion-evaluator/orion_evaluator/evaluator.py
@@ -4,6 +4,7 @@ import json
 
 from . import ffi
 from .errors import EvaluatorError
+from .gohandle import GoHandle
 from .model import Model
 
 
@@ -32,7 +33,7 @@ class Evaluator:
             btp_keys_bytes: bootstrapping.EvaluationKeys.MarshalBinary() output (optional)
         """
         params_json = json.dumps(params)
-        self._handle = ffi.new_evaluator(params_json, keys_bytes, btp_keys_bytes)
+        self._handle: GoHandle | None = ffi.new_evaluator(params_json, keys_bytes, btp_keys_bytes)
 
     def forward(self, model: Model, ct_bytes_list: list[bytes]) -> list[bytes]:
         """Run FHE forward pass.

--- a/python/orion-evaluator/orion_evaluator/ffi.py
+++ b/python/orion-evaluator/orion_evaluator/ffi.py
@@ -194,7 +194,9 @@ def model_close(handle: GoHandle) -> None:
 # =========================================================================
 
 
-def new_evaluator(params_json: str, keys_bytes: bytes, btp_keys_bytes: bytes | None = None) -> GoHandle:
+def new_evaluator(
+    params_json: str, keys_bytes: bytes, btp_keys_bytes: bytes | None = None
+) -> GoHandle:
     """Create evaluator from params JSON and MemEvaluationKeySet bytes."""
     lib = _lib_call()
     err = _make_errout()
@@ -239,7 +241,9 @@ def _unpack_ct_list(data: bytes) -> list[bytes]:
     return result
 
 
-def evaluator_forward(eval_handle: GoHandle, model_handle: GoHandle, ct_bytes_list: list[bytes]) -> list[bytes]:
+def evaluator_forward(
+    eval_handle: GoHandle, model_handle: GoHandle, ct_bytes_list: list[bytes]
+) -> list[bytes]:
     """Run forward pass. Accepts/returns lists of Lattigo ciphertext binary bytes."""
     lib = _lib_call()
     err = _make_errout()

--- a/python/orion-evaluator/orion_evaluator/gohandle.py
+++ b/python/orion-evaluator/orion_evaluator/gohandle.py
@@ -4,6 +4,8 @@ Mirrors lattigo.gohandle.GoHandle for consistent handle lifecycle management
 across all Orion FFI packages.
 """
 
+from collections.abc import Callable
+
 from .errors import EvaluatorError
 
 
@@ -14,9 +16,9 @@ class HandleClosedError(EvaluatorError):
 class GoHandle:
     """RAII wrapper for a cgo.Handle (opaque uintptr_t). Idempotent close."""
 
-    __slots__ = ("_raw", "_tag", "_delete_fn")
+    __slots__ = ("_delete_fn", "_raw", "_tag")
 
-    def __init__(self, raw: int, tag: str = "", *, delete_fn: object = None):
+    def __init__(self, raw: int, tag: str = "", *, delete_fn: Callable[[int], None] | None = None):
         self._raw = raw
         self._tag = tag
         self._delete_fn = delete_fn

--- a/python/orion-evaluator/orion_evaluator/model.py
+++ b/python/orion-evaluator/orion_evaluator/model.py
@@ -21,7 +21,7 @@ class Model:
     __slots__ = ("_handle",)
 
     def __init__(self, handle: GoHandle):
-        self._handle = handle
+        self._handle: GoHandle | None = handle
 
     @classmethod
     def load(cls, data: bytes) -> "Model":

--- a/python/tests/test_bootstrap_dag.py
+++ b/python/tests/test_bootstrap_dag.py
@@ -3,13 +3,21 @@
 Task 4: Bootstrap operations become explicit DAG nodes instead of forward hooks.
 """
 
+import gc
 import types
 from unittest.mock import MagicMock
 
 import networkx as nx
+import orion_compiler.nn as on
 import torch
+from orion_compiler.compiler import Compiler
 from orion_compiler.core.auto_bootstrap import BootstrapPlacer, BootstrapSolver
+from orion_compiler.core.fuser import Fuser
+from orion_compiler.core.network_dag import NetworkDAG
+from orion_compiler.nn.linear import LinearTransform
+from orion_compiler.nn.module import Module
 from orion_compiler.nn.operations import Bootstrap
+from orion_compiler.params import CKKSParams
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -285,10 +293,6 @@ class TestBootstrapIntegration:
 
         Verifies that boot_* nodes appear in the DAG after compilation.
         """
-        import orion_compiler.nn as on
-        from orion_compiler.compiler import Compiler
-        from orion_compiler.params import CKKSParams
-
         # Short logq chain: l_eff = 2 (only 2 usable levels).
         # MLP with 2 linear layers + 1 quad = 3 depth -> bootstraps needed.
         short_params = CKKSParams(
@@ -320,10 +324,6 @@ class TestBootstrapIntegration:
 
         # Access the internal DAG to verify bootstrap insertion.
         # We need to replicate the compile() steps up to bootstrap placement.
-        from orion_compiler.core.fuser import Fuser
-        from orion_compiler.core.network_dag import NetworkDAG
-        from orion_compiler.nn.module import Module
-
         network_dag = NetworkDAG(compiler._traced)
         network_dag.build_dag()
 
@@ -345,8 +345,6 @@ class TestBootstrapIntegration:
             network_dag.remove_fused_batchnorms()
 
         topo_sort = list(network_dag.topological_sort())
-        from orion_compiler.nn.linear import LinearTransform
-
         last_linear = None
         for node in reversed(topo_sort):
             module = network_dag.nodes[node]["module"]
@@ -401,6 +399,4 @@ class TestBootstrapIntegration:
             assert len(succs) >= 1, f"{bn} has no successors"
 
         del compiler
-        import gc
-
         gc.collect()

--- a/python/tests/test_compiled_format.py
+++ b/python/tests/test_compiled_format.py
@@ -446,6 +446,8 @@ class TestBlobFormat:
                 for ref_name, idx in node.blob_refs.items():
                     if ref_name.startswith("bias_"):
                         blob = compiled.blobs[idx]
-                        assert len(blob) == max_slots * 8, (
-                            f"Bias blob {ref_name} for {node.name}: expected {max_slots * 8} bytes, got {len(blob)}"
+                        expected = max_slots * 8
+                        assert len(blob) == expected, (
+                            f"Bias blob {ref_name} for {node.name}: "
+                            f"expected {expected} bytes, got {len(blob)}"
                         )

--- a/python/tests/test_exceptions.py
+++ b/python/tests/test_exceptions.py
@@ -3,6 +3,7 @@
 import pytest
 from lattigo.errors import FFIError, HandleClosedError, LatticeError
 from orion_compiler.errors import CompilationError, CompilerError, ValidationError
+from orion_compiler.params import CKKSParams
 from orion_evaluator.errors import EvaluatorError, ModelLoadError
 
 
@@ -118,19 +119,13 @@ class TestValidationErrorIntegration:
     """Test that ValidationError is raised by CKKSParams validation."""
 
     def test_invalid_logn_raises_validation_error(self):
-        from orion_compiler.params import CKKSParams
-
         with pytest.raises(ValidationError, match="logn must be positive"):
             CKKSParams(logn=0, logq=[40], logp=[40], log_default_scale=40)
 
     def test_empty_logq_raises_validation_error(self):
-        from orion_compiler.params import CKKSParams
-
         with pytest.raises(ValidationError, match="logq must be non-empty"):
             CKKSParams(logn=13, logq=[], logp=[40], log_default_scale=40)
 
     def test_invalid_ring_type_raises_validation_error(self):
-        from orion_compiler.params import CKKSParams
-
         with pytest.raises(ValidationError, match="ring_type must be one of"):
             CKKSParams(logn=13, logq=[40], logp=[40], log_default_scale=40, ring_type="invalid")

--- a/python/tests/test_logging.py
+++ b/python/tests/test_logging.py
@@ -1,12 +1,15 @@
 """Tests for logging configuration in orion-compiler library code."""
 
+import ast
+import inspect
 import logging
+
+from orion_compiler import compiler
+from orion_compiler.core import auto_bootstrap, level_dag, network_dag, packing, utils
 
 
 def test_compiler_logger_name():
     """Verify that compiler.py logger name matches its module."""
-    from orion_compiler import compiler
-
     assert hasattr(compiler, "logger")
     assert compiler.logger.name == "orion_compiler.compiler"
     assert isinstance(compiler.logger, logging.Logger)
@@ -14,8 +17,6 @@ def test_compiler_logger_name():
 
 def test_packing_logger_name():
     """Verify that packing.py logger name matches its module."""
-    from orion_compiler.core import packing
-
     assert hasattr(packing, "logger")
     assert packing.logger.name == "orion_compiler.core.packing"
     assert isinstance(packing.logger, logging.Logger)
@@ -23,8 +24,6 @@ def test_packing_logger_name():
 
 def test_auto_bootstrap_logger_name():
     """Verify that auto_bootstrap.py logger name matches its module."""
-    from orion_compiler.core import auto_bootstrap
-
     assert hasattr(auto_bootstrap, "logger")
     assert auto_bootstrap.logger.name == "orion_compiler.core.auto_bootstrap"
     assert isinstance(auto_bootstrap.logger, logging.Logger)
@@ -32,8 +31,6 @@ def test_auto_bootstrap_logger_name():
 
 def test_network_dag_logger_name():
     """Verify that network_dag.py logger name matches its module."""
-    from orion_compiler.core import network_dag
-
     assert hasattr(network_dag, "logger")
     assert network_dag.logger.name == "orion_compiler.core.network_dag"
     assert isinstance(network_dag.logger, logging.Logger)
@@ -41,8 +38,6 @@ def test_network_dag_logger_name():
 
 def test_level_dag_logger_name():
     """Verify that level_dag.py logger name matches its module."""
-    from orion_compiler.core import level_dag
-
     assert hasattr(level_dag, "logger")
     assert level_dag.logger.name == "orion_compiler.core.level_dag"
     assert isinstance(level_dag.logger, logging.Logger)
@@ -50,8 +45,6 @@ def test_level_dag_logger_name():
 
 def test_utils_logger_name():
     """Verify that utils.py logger name matches its module."""
-    from orion_compiler.core import utils
-
     assert hasattr(utils, "logger")
     assert utils.logger.name == "orion_compiler.core.utils"
     assert isinstance(utils.logger, logging.Logger)
@@ -63,12 +56,6 @@ def test_no_print_in_library_modules():
     Scans source code of modules that previously used print() to ensure
     no print() calls remain (excluding comments).
     """
-    import ast
-    import inspect
-
-    from orion_compiler import compiler
-    from orion_compiler.core import auto_bootstrap, level_dag, network_dag, packing, utils
-
     modules = [compiler, packing, auto_bootstrap, network_dag, level_dag, utils]
     for mod in modules:
         assert hasattr(mod, "logger"), f"{mod.__name__} missing logger attribute"

--- a/python/tests/test_orion_evaluator.py
+++ b/python/tests/test_orion_evaluator.py
@@ -9,15 +9,21 @@ import gc
 import json
 import os
 
+import orion_compiler.nn as on
 import pytest
 import torch
 from lattigo.ckks import Encoder, Parameters
+from lattigo.rlwe import (
+    Ciphertext as RLWECiphertext,
+)
 from lattigo.rlwe import (
     Decryptor,
     Encryptor,
     KeyGenerator,
     MemEvaluationKeySet,
 )
+from orion_compiler.compiler import Compiler
+from orion_compiler.params import CKKSParams
 from orion_evaluator import Evaluator, EvaluatorError, Model
 from orion_evaluator.errors import ModelLoadError
 
@@ -45,7 +51,8 @@ def _params_from_dict(params_dict: dict) -> Parameters:
 class TestModelLifecycle:
     def test_load_valid_model(self):
         """Model.load succeeds on valid .orion file."""
-        data = open(MLP_ORION, "rb").read()
+        with open(MLP_ORION, "rb") as f:
+            data = f.read()
         model = Model.load(data)
         assert model._handle != 0
         model.close()
@@ -53,7 +60,8 @@ class TestModelLifecycle:
 
     def test_client_params(self):
         """Model.client_params returns valid params, manifest, input_level."""
-        data = open(MLP_ORION, "rb").read()
+        with open(MLP_ORION, "rb") as f:
+            data = f.read()
         model = Model.load(data)
         params, manifest, input_level = model.client_params()
 
@@ -76,7 +84,8 @@ class TestModelLifecycle:
 
     def test_close_is_idempotent(self):
         """Closing a model twice does not crash."""
-        data = open(MLP_ORION, "rb").read()
+        with open(MLP_ORION, "rb") as f:
+            data = f.read()
         model = Model.load(data)
         model.close()
         model.close()  # should not raise
@@ -84,7 +93,8 @@ class TestModelLifecycle:
 
     def test_closed_model_raises(self):
         """Operations on closed model raise."""
-        data = open(MLP_ORION, "rb").read()
+        with open(MLP_ORION, "rb") as f:
+            data = f.read()
         model = Model.load(data)
         model.close()
         with pytest.raises(EvaluatorError, match="closed"):
@@ -132,7 +142,8 @@ def _make_evaluator_from_model(model):
 class TestEvaluatorLifecycle:
     def test_create_and_close(self):
         """Evaluator can be created and closed."""
-        data = open(MLP_ORION, "rb").read()
+        with open(MLP_ORION, "rb") as f:
+            data = f.read()
         model = Model.load(data)
         evaluator, sk, params, kg = _make_evaluator_from_model(model)
 
@@ -148,7 +159,8 @@ class TestEvaluatorLifecycle:
 
     def test_close_is_idempotent(self):
         """Closing evaluator twice does not crash."""
-        data = open(MLP_ORION, "rb").read()
+        with open(MLP_ORION, "rb") as f:
+            data = f.read()
         model = Model.load(data)
         evaluator, sk, params, kg = _make_evaluator_from_model(model)
 
@@ -163,7 +175,8 @@ class TestEvaluatorLifecycle:
 
     def test_closed_evaluator_raises(self):
         """Operations on closed evaluator raise."""
-        data = open(MLP_ORION, "rb").read()
+        with open(MLP_ORION, "rb") as f:
+            data = f.read()
         model = Model.load(data)
         evaluator, sk, params, kg = _make_evaluator_from_model(model)
         evaluator.close()
@@ -186,7 +199,8 @@ class TestEvaluatorLifecycle:
 class TestBootstrapKeyParameter:
     def test_evaluator_without_btp_keys_on_non_bootstrap_model(self):
         """Evaluator(params, keys, btp_keys_bytes=None) works for non-bootstrap model."""
-        data = open(MLP_ORION, "rb").read()
+        with open(MLP_ORION, "rb") as f:
+            data = f.read()
         model = Model.load(data)
         params_dict, manifest, _input_level = model.client_params()
         params = _params_from_dict(params_dict)
@@ -216,7 +230,8 @@ class TestBootstrapKeyParameter:
 
     def test_evaluator_positional_btp_keys_none(self):
         """Evaluator(params, keys, None) works same as omitting btp_keys_bytes."""
-        data = open(MLP_ORION, "rb").read()
+        with open(MLP_ORION, "rb") as f:
+            data = f.read()
         model = Model.load(data)
         params_dict, manifest, _input_level = model.client_params()
         params = _params_from_dict(params_dict)
@@ -246,7 +261,8 @@ class TestBootstrapKeyParameter:
 
     def test_forward_without_btp_keys_e2e(self):
         """E2E forward pass with explicit btp_keys_bytes=None works on non-bootstrap model."""
-        model_data = open(MLP_ORION, "rb").read()
+        with open(MLP_ORION, "rb") as f:
+            model_data = f.read()
         model = Model.load(model_data)
         params_dict, manifest, input_level = model.client_params()
 
@@ -281,8 +297,6 @@ class TestBootstrapKeyParameter:
         result_bytes = result_bytes_list[0]
         assert isinstance(result_bytes, bytes)
         assert len(result_bytes) > 0
-
-        from lattigo.rlwe import Ciphertext as RLWECiphertext
 
         result_ct = RLWECiphertext.unmarshal_binary(result_bytes)
         result_pt = decryptor.decrypt_new(result_ct)
@@ -328,7 +342,8 @@ class TestE2EForward:
         Uses the pre-compiled mlp.orion test model with known input/expected output.
         """
         # Load model
-        model_data = open(MLP_ORION, "rb").read()
+        with open(MLP_ORION, "rb") as f:
+            model_data = f.read()
         model = Model.load(model_data)
         params_dict, manifest, input_level = model.client_params()
 
@@ -370,8 +385,6 @@ class TestE2EForward:
         assert len(result_bytes) > 0
 
         # Decrypt result
-        from lattigo.rlwe import Ciphertext as RLWECiphertext
-
         result_ct = RLWECiphertext.unmarshal_binary(result_bytes)
         result_pt = decryptor.decrypt_new(result_ct)
         decoded = encoder.decode(result_pt, max_slots)
@@ -413,9 +426,6 @@ class TestE2EForward:
 
         This test exercises the full pipeline from PyTorch model to encrypted inference.
         """
-        import orion_compiler.nn as on
-        from orion_compiler.compiler import Compiler
-        from orion_compiler.params import CKKSParams
 
         class TinyMLP(on.Module):
             def __init__(self):
@@ -482,8 +492,6 @@ class TestE2EForward:
         result_bytes = result_bytes_list[0]
 
         # Decrypt
-        from lattigo.rlwe import Ciphertext as RLWECiphertext
-
         result_ct = RLWECiphertext.unmarshal_binary(result_bytes)
         result_pt = decryptor.decrypt_new(result_ct)
         decoded = encoder.decode(result_pt, max_slots)
@@ -525,9 +533,6 @@ class TestE2EForward:
 
     def test_forward_conv2d_small_channels(self):
         """E2E: Conv2d(1,5,k=2,s=2,p=0) with small channel count and output rotations."""
-        import orion_compiler.nn as on
-        from orion_compiler.compiler import Compiler
-        from orion_compiler.params import CKKSParams
 
         class SmallConvNet(on.Module):
             """Minimal Conv2d model with small channel count and output rotations."""
@@ -596,8 +601,6 @@ class TestE2EForward:
         result_bytes = result_bytes_list[0]
 
         # Decrypt
-        from lattigo.rlwe import Ciphertext as RLWECiphertext
-
         result_ct = RLWECiphertext.unmarshal_binary(result_bytes)
         result_pt = decryptor.decrypt_new(result_ct)
         decoded = encoder.decode(result_pt, max_slots)

--- a/python/tests/test_v2_api.py
+++ b/python/tests/test_v2_api.py
@@ -7,6 +7,7 @@ import gc
 import json
 import struct
 
+import networkx as nx
 import orion_compiler.nn as on
 import pytest
 import torch
@@ -237,8 +238,6 @@ class TestCompiler:
 
     def test_edges_form_valid_dag(self, compiled_mlp):
         """Edges form a valid DAG (acyclic)."""
-        import networkx as nx
-
         compiled = compiled_mlp
         g = nx.DiGraph()
         for node in compiled.graph.nodes:

--- a/python/tests/test_v2_dataclasses.py
+++ b/python/tests/test_v2_dataclasses.py
@@ -1,6 +1,8 @@
 """Unit tests for v2 data structures: CKKSParams, CompilerConfig,
 KeyManifest, CompiledModel, EvalKeys, and the NewParameters adapter."""
 
+import json
+
 import pytest
 from orion_compiler.compiled_model import (
     CompiledModel,
@@ -97,15 +99,11 @@ class TestCKKSParams:
         assert p.btp_logn == 16
 
     def test_btp_logn_in_bridge_json(self):
-        import json
-
         p = self._default_params(boot_logp=(61, 61), btp_logn=15)
         d = json.loads(p.to_bridge_json())
         assert d["btp_logn"] == 15
 
     def test_btp_logn_absent_from_bridge_json_when_none(self):
-        import json
-
         p = self._default_params()
         d = json.loads(p.to_bridge_json())
         assert "btp_logn" not in d


### PR DESCRIPTION
## Summary
- Enable `PLC0415` (imports at top level) with ruff preview mode
- Remove `SIM115` from per-file-ignores for tests (enforce context managers for `open()`)
- Fix all ruff violations across codebase: E501, F401, I001, B905, RUF023, PLC0415, SIM115
- Fix all mypy errors: proper type annotations for `GoHandle`, `Callable`, `Iterator`, nullable handles
- Add `.pre-commit-config.yaml` with ruff (check + format) and mypy hooks

## Test plan
- [x] `ruff check python/` passes with 0 errors
- [x] `mypy python/lattigo/ python/orion-compiler/ python/orion-evaluator/` passes with 0 errors
- [x] Pre-commit hooks (ruff, ruff-format, mypy) all pass on commit

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)