### PR TITLE
ci: add npm publishing to release workflow

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -32,7 +32,7 @@ Update the `version` field in these files (and only these — do NOT touch `pyth
 4. Push to main: `git push origin main`
 5. Create and push tag: `git tag v$ARGUMENTS && git push origin v$ARGUMENTS`
 6. Monitor the release workflow: `gh run list --workflow release.yml --limit 1`
-   - The release workflow builds Python wheels, publishes to PyPI, and creates a GitHub Release
+   - The release workflow builds Python wheels, publishes to PyPI, publishes `js/lattigo` to npm, and creates a GitHub Release
 7. Print the GitHub Release URL when done: `https://github.com/butvinm/orion/releases/tag/v$ARGUMENTS`
 
 ## What NOT to bump

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,39 @@ jobs:
           skip-existing: true
           verbose: true
 
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: npm
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
+
+      - name: Install JS dependencies
+        working-directory: js/lattigo
+        run: npm install
+
+      - name: Build WASM and TypeScript
+        working-directory: js/lattigo
+        run: npm run build
+
+      - name: Publish to npm
+        working-directory: js/lattigo
+        run: npm publish --provenance --access public
+
   github-release:
     needs: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add `publish-npm` job to release workflow that builds WASM + TypeScript and publishes `orion-v2-lattigo` to npm on tag push
- Uses OIDC trusted publishing (no `NPM_TOKEN` secret needed)
- Requires `npm` GitHub environment (already created)
- Initial publish of `orion-v2-lattigo@6.2.0` already done manually

Closes #4

## Test plan
- [x] Package published manually: https://www.npmjs.com/package/orion-v2-lattigo
- [x] Configure trusted publisher on npmjs.com for OIDC
- [ ] Verify on next tag push that `publish-npm` job succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)