### PR TITLE
ci: split lattigo into independent Python and JS release workflows

### DIFF
--- a/.claude/skills/release-lattigo/SKILL.md
+++ b/.claude/skills/release-lattigo/SKILL.md
@@ -1,8 +1,17 @@
 # Release Lattigo Bindings
 
-Create a new release of lattigo binding packages (orion-v2-lattigo on PyPI and npm).
+Release a lattigo binding package independently.
 
-**Arguments:** `$ARGUMENTS` — the version to release (e.g. `6.3.0`). Must match the upstream Lattigo version these bindings target. Required.
+**Arguments:** `$ARGUMENTS` — format: `<target> <version>` where target is `py` or `js`. Example: `py 6.2.3` or `js 6.2.1`. Required.
+
+## Versioning
+
+Lattigo binding versions use 3-part semver matching upstream Lattigo's major.minor, with patch for our changes:
+
+- `6.2.0` — initial bindings for upstream Lattigo 6.2.0
+- `6.2.1` — our patch to the bindings (Python or JS independently)
+
+Python and JS versions are **independent** — they don't need to match.
 
 ## Prerequisites
 
@@ -10,30 +19,32 @@ Before starting, verify:
 
 1. Working tree is clean (`git status` shows no uncommitted changes)
 2. On `main` branch
-3. CI is passing on the latest commit: `gh pr checks` or check the latest CI run
-4. The version tag does not already exist: `git tag -l "lattigo-v$ARGUMENTS"`
-5. Both lattigo packages have the same version set to `$ARGUMENTS`:
-   - `python/lattigo/pyproject.toml`
-   - `js/lattigo/package.json`
+3. CI is passing on the latest commit
+4. The version tag does not already exist:
+   - For `py`: `git tag -l "lattigo-py-v<version>"`
+   - For `js`: `git tag -l "lattigo-js-v<version>"`
 
-If the versions don't match `$ARGUMENTS`, bump them first.
+If any check fails, stop and tell the user.
 
-## Version files to bump (if needed)
+## Version file to bump
 
-- `python/lattigo/pyproject.toml`
-- `js/lattigo/package.json`
+- For `py`: `python/lattigo/pyproject.toml`
+- For `js`: `js/lattigo/package.json`
 
 ## Steps
 
 1. Run all prerequisite checks
-2. If versions need bumping, update both files and commit: `chore: bump lattigo bindings to $ARGUMENTS`
-   - Stage only the 2 specific files, never `git add .`
+2. If version needs bumping, update the file and commit: `chore: bump lattigo <target> bindings to <version>`
+   - Stage only the 1 specific file, never `git add .`
 3. Push to main: `git push origin main`
-4. Create and push tag: `git tag lattigo-v$ARGUMENTS && git push origin lattigo-v$ARGUMENTS`
-5. Monitor the release workflow: `gh run list --workflow release-lattigo.yml --limit 1`
-   - The workflow builds Python wheel (CGO) and JS/WASM package, publishes to PyPI and npm, and creates a GitHub Release
-6. Print the GitHub Release URL when done: `https://github.com/butvinm/orion/releases/tag/lattigo-v$ARGUMENTS`
+4. Create and push tag:
+   - For `py`: `git tag lattigo-py-v<version> && git push origin lattigo-py-v<version>`
+   - For `js`: `git tag lattigo-js-v<version> && git push origin lattigo-js-v<version>`
+5. Monitor the release workflow:
+   - For `py`: `gh run list --workflow release-lattigo-python.yml --limit 1`
+   - For `js`: `gh run list --workflow release-lattigo-js.yml --limit 1`
+6. Print the GitHub Release URL when done
 
 ## What this does NOT publish
 
-- `orion-compiler` and `orion-evaluator` have their own release workflow (`release.yml`), triggered by `v*` tags. Use `/release` for those.
+- `orion-compiler` and `orion-evaluator` use `/release` (triggered by `v*` tags).

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -37,4 +37,6 @@ Update the `version` field in these files (and only these):
 
 ## What this does NOT publish
 
-- `python/lattigo/` and `js/lattigo/` have their own release workflow (`release-lattigo.yml`), triggered by `lattigo-v*` tags. Use `/release-lattigo` for those.
+- `python/lattigo/` uses `release-lattigo-python.yml` (`lattigo-py-v*` tags)
+- `js/lattigo/` uses `release-lattigo-js.yml` (`lattigo-js-v*` tags)
+- Use `/release-lattigo py <version>` or `/release-lattigo js <version>` for those.

--- a/.github/workflows/release-lattigo-js.yml
+++ b/.github/workflows/release-lattigo-js.yml
@@ -1,0 +1,49 @@
+name: Release Lattigo JS Bindings
+
+on:
+  push:
+    tags:
+      - "lattigo-js-v*"
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment: npm
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
+
+      - name: Install JS dependencies
+        working-directory: js/lattigo
+        run: npm install
+
+      - name: Build WASM and TypeScript
+        working-directory: js/lattigo
+        run: npm run build
+
+      - name: Publish to npm
+        working-directory: js/lattigo
+        run: npm publish --provenance --access public
+
+  github-release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true

--- a/.github/workflows/release-lattigo-python.yml
+++ b/.github/workflows/release-lattigo-python.yml
@@ -1,16 +1,16 @@
-name: Release Lattigo Bindings
+name: Release Lattigo Python Bindings
 
 on:
   push:
     tags:
-      - "lattigo-v*"
+      - "lattigo-py-v*"
 
 permissions:
   contents: write
   id-token: write
 
 jobs:
-  build-python:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -41,7 +41,7 @@ jobs:
           path: dist/
 
   publish-pypi:
-    needs: build-python
+    needs: build
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -58,40 +58,8 @@ jobs:
           packages-dir: dist/
           verbose: true
 
-  publish-npm:
-    runs-on: ubuntu-latest
-    environment: npm
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version: "1.24"
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-
-      - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
-
-      - name: Install JS dependencies
-        working-directory: js/lattigo
-        run: npm install
-
-      - name: Build WASM and TypeScript
-        working-directory: js/lattigo
-        run: npm run build
-
-      - name: Publish to npm
-        working-directory: js/lattigo
-        run: npm publish --provenance --access public
-
   github-release:
-    needs: [publish-pypi, publish-npm]
+    needs: publish-pypi
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary

- Split `release-lattigo.yml` into two independent workflows:
  - `release-lattigo-python.yml` (`lattigo-py-v*` tags) → PyPI
  - `release-lattigo-js.yml` (`lattigo-js-v*` tags) → npm
- Python and JS lattigo versions are independent — both use 3-part semver (upstream major.minor + our patch)
- Update `/release-lattigo` skill to accept target: `/release-lattigo py 6.2.3` or `/release-lattigo js 6.2.1`

## Why

Python lattigo (6.2.2) and JS lattigo (6.2.0) are already at different versions. They should release independently since changes to CGO bindings don't affect WASM bindings and vice versa.

## Trusted publishers needed

Before testing, add trusted publishers on both registries:
- **PyPI** (orion-v2-lattigo): workflow `release-lattigo-python.yml`, environment `pypi`
- **npm** (orion-v2-lattigo): workflow `release-lattigo-js.yml`, environment `npm`

## Test plan
- [ ] Configure trusted publishers on PyPI and npm
- [ ] Tag `lattigo-py-v6.2.3` to test Python-only release
- [ ] Tag `lattigo-js-v6.2.3` to test JS-only release

🤖 Generated with [Claude Code](https://claude.com/claude-code)