### PR TITLE
chore: bump version to 2.1.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orion"
-version = "2.1.4"
+version = "2.1.5"
 description = "FHE framework for deep learning inference"
 requires-python = ">=3.11"
 license = "MIT"

--- a/python/orion-compiler/pyproject.toml
+++ b/python/orion-compiler/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "orion-v2-compiler"
-version = "2.1.4"
+version = "2.1.5"
 description = "Orion FHE compiler — traces, fits, and compiles PyTorch neural networks for encrypted inference"
 requires-python = ">=3.11"
 license = "MIT"

--- a/python/orion-evaluator/pyproject.toml
+++ b/python/orion-evaluator/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "orion-v2-evaluator"
-version = "2.1.4"
+version = "2.1.5"
 description = "Python bindings for the Orion FHE evaluator"
 requires-python = ">=3.11"
 license = "MIT"


### PR DESCRIPTION
Version bump for the 2.1.5 release.

Includes:
- Pre-encode LinearTransformations at Model load time (#28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)