### PR TITLE
feat(compiler): reserve_output_levels for downstream MAC (v2.1.6)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orion"
-version = "2.1.5"
+version = "2.1.6"
 description = "FHE framework for deep learning inference"
 requires-python = ">=3.11"
 license = "MIT"

--- a/python/orion-compiler/orion_compiler/compiled_model.py
+++ b/python/orion-compiler/orion_compiler/compiled_model.py
@@ -368,6 +368,7 @@ class CompiledModel:
                 "margin": self.config.margin,
                 "embedding_method": self.config.embedding_method,
                 "fuse_modules": self.config.fuse_modules,
+                "reserve_output_levels": self.config.reserve_output_levels,
             },
             "manifest": self.manifest.to_dict(),
             "input_level": self.input_level,
@@ -421,6 +422,7 @@ class CompiledModel:
             margin=c["margin"],
             embedding_method=c["embedding_method"],
             fuse_modules=c["fuse_modules"],
+            reserve_output_levels=c.get("reserve_output_levels", 0),
         )
 
         manifest = KeyManifest.from_dict(metadata["manifest"])

--- a/python/orion-compiler/orion_compiler/compiler.py
+++ b/python/orion-compiler/orion_compiler/compiler.py
@@ -328,7 +328,13 @@ class Compiler:
         logger.info("[4/5] Running bootstrap placement...")
         start = time.time()
         l_eff = len(self.params.get_logq()) - 1
-        btp_solver = BootstrapSolver(net, network_dag, l_eff=l_eff, context=self._context)
+        btp_solver = BootstrapSolver(
+            net,
+            network_dag,
+            l_eff=l_eff,
+            context=self._context,
+            reserve_output_levels=self.config.reserve_output_levels,
+        )
         input_level, num_bootstraps, bootstrapper_slots = btp_solver.solve()
         logger.info("Bootstrap placement done! [%.3f secs.]", time.time() - start)
         logger.info(

--- a/python/orion-compiler/orion_compiler/core/auto_bootstrap.py
+++ b/python/orion-compiler/orion_compiler/core/auto_bootstrap.py
@@ -18,6 +18,20 @@ from .network_dag import NetworkDAG
 logger = logging.getLogger(__name__)
 
 
+def _shift_layer_level(layer: str, shift: int) -> str:
+    """Rewrite a ``"<name>@level=<N>"`` entry, bumping N by ``shift``.
+
+    Used by the protocol-reserve shift in ``BootstrapSolver``. The entry
+    string format is produced by ``LevelDAG`` when it builds nodes with
+    embedded level annotations; this helper is the single place that
+    parses-then-rewrites that format.
+    """
+    name, _, level_part = layer.partition("@level=")
+    if not _:
+        raise ValueError(f"layer entry missing '@level=' separator: {layer!r}")
+    return f"{name}@level={int(level_part) + shift}"
+
+
 class BootstrapSolver:
     def __init__(
         self,
@@ -25,11 +39,15 @@ class BootstrapSolver:
         network_dag: NetworkDAG,
         l_eff: int,
         context: CompilationContext | None = None,
+        reserve_output_levels: int = 0,
     ) -> None:
+        if reserve_output_levels < 0:
+            raise ValueError(f"reserve_output_levels must be >= 0, got {reserve_output_levels}")
         self.net = net
         self.network_dag = network_dag
         self.l_eff = l_eff
         self.context = context
+        self.reserve_output_levels = reserve_output_levels
         self.full_level_dag = LevelDAG(l_eff=l_eff, network_dag=network_dag)
         self.shortest_path: set[str] = set()
 
@@ -135,9 +153,34 @@ class BootstrapSolver:
             edge = self.full_level_dag[u][v]
             reconstructed_path.update(edge["path"])
 
+        # Protocol-reserve shift: bump every node's level annotation up by
+        # `reserve_output_levels` so the compiled circuit's plaintexts are
+        # encoded at the higher moduli and the final node ends at level
+        # `reserve_output_levels` rather than 0. The user must have provided
+        # at least that many extra primes in CKKSParams.logq; otherwise the
+        # bumped input_level would exceed l_eff and we raise.
+        if self.reserve_output_levels > 0:
+            reconstructed_path = {
+                _shift_layer_level(entry, self.reserve_output_levels)
+                for entry in reconstructed_path
+            }
+            shortest_path = [
+                _shift_layer_level(entry, self.reserve_output_levels)
+                if "@level=" in entry
+                else entry
+                for entry in shortest_path
+            ]
+
         self.shortest_path = reconstructed_path
 
         input_level = int(shortest_path[1].split("=")[-1])
+        if input_level > self.l_eff:
+            raise ValueError(
+                f"BootstrapSolver: reserve_output_levels={self.reserve_output_levels} "
+                f"pushes input_level={input_level} beyond l_eff={self.l_eff}; "
+                f"extend CKKSParams.logq by at least "
+                f"{input_level - self.l_eff} more prime(s)"
+            )
         return input_level
 
     def solve(self) -> tuple[int, int, list[int]]:

--- a/python/orion-compiler/orion_compiler/params.py
+++ b/python/orion-compiler/orion_compiler/params.py
@@ -142,10 +142,28 @@ class CompilerConfig:
     margin: int = 2
     embedding_method: Literal["hybrid", "square"] = "hybrid"
     fuse_modules: bool = True
+    reserve_output_levels: int = 0
+    """Extra Q-chain levels to leave free at the *output* of the compiled
+    circuit. The bootstrap solver normally picks the minimum ``input_level``
+    that fits the graph and schedules every layer so the final node lands
+    at level 0. When ``reserve_output_levels > 0`` the solver bumps
+    ``input_level`` by this amount and shifts every node's level annotation
+    up by the same amount, so the final node lands at level
+    ``reserve_output_levels`` instead. Callers that need to perform extra
+    operations on ``result_ct`` after ``Model.Forward`` (e.g. an
+    authenticator's slot-mask multiply that requires ``Level() >= 1``)
+    should set this to the number of multiplicative levels their
+    post-processing consumes. The user's ``CKKSParams.logq`` must have at
+    least ``reserve_output_levels`` more primes than the un-reserved model
+    would need, or compilation will raise."""
 
     def __post_init__(self) -> None:
         valid_methods = {"hybrid", "square"}
         if self.embedding_method not in valid_methods:
             raise ValidationError(
                 f"embedding_method must be one of {valid_methods}, got '{self.embedding_method}'"
+            )
+        if self.reserve_output_levels < 0:
+            raise ValidationError(
+                f"reserve_output_levels must be >= 0, got {self.reserve_output_levels}"
             )

--- a/python/orion-compiler/pyproject.toml
+++ b/python/orion-compiler/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "orion-v2-compiler"
-version = "2.1.5"
+version = "2.1.6"
 description = "Orion FHE compiler — traces, fits, and compiles PyTorch neural networks for encrypted inference"
 requires-python = ">=3.11"
 license = "MIT"

--- a/python/orion-evaluator/pyproject.toml
+++ b/python/orion-evaluator/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "orion-v2-evaluator"
-version = "2.1.5"
+version = "2.1.6"
 description = "Python bindings for the Orion FHE evaluator"
 requires-python = ">=3.11"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Adds `CompilerConfig.reserve_output_levels: int = 0`, plumbed through to `BootstrapSolver`, so callers can leave Q-chain headroom at the output ciphertext for downstream operations (e.g. a MAC `MulNew(slot_mask, result_ct)` that requires `Level() >= 1`).
- Solver bumps the returned `input_level` and shifts every level annotation in `shortest_path` so `assign_levels_to_layers` propagates the bump into every node's `module.level`. Plaintexts are encoded at the bumped moduli; lattigo's level-drop inside LT ops no longer eats the reserve.
- Persists `reserve_output_levels` in `.orion` metadata; reading pre-2.1.6 models defaults to 0 (fully backward-compatible).
- Bumps all three pyproject files (root, orion-compiler, orion-evaluator) to 2.1.6 so a single `v2.1.6` tag can publish the release.

## Test plan
- [ ] CI green on this branch
- [ ] Compile a C3AE model with `reserve_output_levels=1` and verify `result_ct.Level() == 1` after `Forward`
- [ ] Load a pre-2.1.6 `.orion` model and confirm `reserve_output_levels` defaults to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)