### PR TITLE
fix(auto_bootstrap): _shift_layer_level handles both @level= and @l= formats (v2.1.7)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orion"
-version = "2.1.6"
+version = "2.1.7"
 description = "FHE framework for deep learning inference"
 requires-python = ">=3.11"
 license = "MIT"

--- a/python/orion-compiler/orion_compiler/core/auto_bootstrap.py
+++ b/python/orion-compiler/orion_compiler/core/auto_bootstrap.py
@@ -19,17 +19,24 @@ logger = logging.getLogger(__name__)
 
 
 def _shift_layer_level(layer: str, shift: int) -> str:
-    """Rewrite a ``"<name>@level=<N>"`` entry, bumping N by ``shift``.
+    """Rewrite a ``"<name>@<label>=<N>"`` entry, bumping N by ``shift``.
 
-    Used by the protocol-reserve shift in ``BootstrapSolver``. The entry
-    string format is produced by ``LevelDAG`` when it builds nodes with
-    embedded level annotations; this helper is the single place that
-    parses-then-rewrites that format.
+    ``LevelDAG`` emits entries in one of two formats — ``name@level=N``
+    in some paths, ``name@l=N`` in others. This helper preserves
+    whichever label was present and only mutates the integer suffix.
+    Matches the parsing pattern in ``assign_levels_to_layers``
+    (``layer.split("@")[0]`` for the name, ``layer.split("=")[-1]`` for
+    the level).
     """
-    name, _, level_part = layer.partition("@level=")
-    if not _:
-        raise ValueError(f"layer entry missing '@level=' separator: {layer!r}")
-    return f"{name}@level={int(level_part) + shift}"
+    name, at_sep, rest = layer.partition("@")
+    if not at_sep:
+        raise ValueError(f"layer entry missing '@' separator: {layer!r}")
+    # rpartition so the integer suffix is grabbed from the LAST '=' —
+    # mirrors the existing `layer.split("=")[-1]` parse pattern.
+    label, eq_sep, level_str = rest.rpartition("=")
+    if not eq_sep:
+        raise ValueError(f"layer entry missing '=' separator: {layer!r}")
+    return f"{name}@{label}={int(level_str) + shift}"
 
 
 class BootstrapSolver:

--- a/python/orion-compiler/pyproject.toml
+++ b/python/orion-compiler/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "orion-v2-compiler"
-version = "2.1.6"
+version = "2.1.7"
 description = "Orion FHE compiler — traces, fits, and compiles PyTorch neural networks for encrypted inference"
 requires-python = ">=3.11"
 license = "MIT"

--- a/python/orion-evaluator/pyproject.toml
+++ b/python/orion-evaluator/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "orion-v2-evaluator"
-version = "2.1.6"
+version = "2.1.7"
 description = "Python bindings for the Orion FHE evaluator"
 requires-python = ">=3.11"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Supersedes broken **v2.1.6**: with `reserve_output_levels > 0`, `_shift_layer_level` only matched the `@level=N` label form. The LevelDAG also emits `@l=N` entries (e.g. C3AE `pool2@l=10`), so any non-trivial network raised on the first such entry it hit.
- Rewrites the helper to mirror the existing split-based parse used by `assign_levels_to_layers`: partition on `@`, then rpartition the remainder on `=`, preserving whichever label string was there. `rpartition` matches the original `split("=")[-1]` semantics for entries with a stray `=` earlier in the string.
- Bumps all three pyproject files to 2.1.7 so the release tag can publish a single coherent revision.

## Test plan
- [ ] CI green on this branch
- [ ] Compile the C3AE model with `reserve_output_levels=1` and confirm no `@l=` parse error

🤖 Generated with [Claude Code](https://claude.com/claude-code)