### PR TITLE
fix(auto_bootstrap): shift every shortest_path entry unconditionally (v2.1.8)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orion"
-version = "2.1.7"
+version = "2.1.8"
 description = "FHE framework for deep learning inference"
 requires-python = ">=3.11"
 license = "MIT"

--- a/python/orion-compiler/orion_compiler/core/auto_bootstrap.py
+++ b/python/orion-compiler/orion_compiler/core/auto_bootstrap.py
@@ -171,11 +171,12 @@ class BootstrapSolver:
                 _shift_layer_level(entry, self.reserve_output_levels)
                 for entry in reconstructed_path
             }
+            # Every entry remaining after the [1:-1] strip is a node-with-
+            # level annotation (`name@<label>=N`). Shift unconditionally so
+            # the bumped value propagates into `input_level` below and the
+            # `assign_levels_to_layers` walk over `self.shortest_path`.
             shortest_path = [
-                _shift_layer_level(entry, self.reserve_output_levels)
-                if "@level=" in entry
-                else entry
-                for entry in shortest_path
+                _shift_layer_level(entry, self.reserve_output_levels) for entry in shortest_path
             ]
 
         self.shortest_path = reconstructed_path

--- a/python/orion-compiler/pyproject.toml
+++ b/python/orion-compiler/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "orion-v2-compiler"
-version = "2.1.7"
+version = "2.1.8"
 description = "Orion FHE compiler — traces, fits, and compiles PyTorch neural networks for encrypted inference"
 requires-python = ">=3.11"
 license = "MIT"

--- a/python/orion-evaluator/pyproject.toml
+++ b/python/orion-evaluator/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "orion-v2-evaluator"
-version = "2.1.7"
+version = "2.1.8"
 description = "Python bindings for the Orion FHE evaluator"
 requires-python = ">=3.11"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Supersedes broken **v2.1.7**. The 2.1.7 level-shift step gated on `if "@level=" in entry`, but LevelDAG emits some entries in `@l=N` form too. Those bypassed the shift while `reconstructed_path` (set via the unconditional set comprehension) WAS shifted — leaving the returned `input_level` un-bumped while the per-node level annotations baked into the compiled model WERE bumped.
- After the `[1:-1]` strip, every entry in `shortest_path` is a node-with-level annotation by construction. Drop the gate; shift unconditionally.
- Bumps all three pyproject files to 2.1.8 so the release tag publishes a single coherent revision.

## Validation
- C3AE compile with `--reserve-output-levels 1` now produces `model.orion` with `input_level=16, MaxLevel=16, |Q|=17` (was `input_level=15, MaxLevel=16, |Q|=17` under 2.1.7 — inconsistent).

## Test plan
- [ ] CI green on this branch
- [ ] C3AE end-to-end FHE run produces correct outputs with `reserve_output_levels=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)